### PR TITLE
Relabel Fosstodon to Mastodon

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -160,7 +160,7 @@ NAVIGATION_ALT_LINKS = {
           "Blog"
         ),
         ("/events/","Events"),
-        ("https://fosstodon.org/@ansible", "Fosstodon"),
+        ("https://fosstodon.org/@ansible", "Mastodon"),
         ("https://discourse.ansible.im/", "Discourse"),
         ("https://github.com/ansible-community", "GitHub"),
     )


### PR DESCRIPTION
Fosstodon is an instance of Mastodon - our Ansible Mastodon presence is on Fosstodon (cf. my Email address is on Gmail)